### PR TITLE
The link flags should go at the end of the command line, else the linker fails.

### DIFF
--- a/render-nodes-minimal/Makefile
+++ b/render-nodes-minimal/Makefile
@@ -4,9 +4,9 @@ all: Makefile $(TARGET)
 
 $(TARGET): main.c
 	gcc -ggdb -O0 -Wall -std=c99 \
+		main.c \
 		`pkg-config --libs --cflags glesv2 egl gbm` \
-		-o $(TARGET) \
-		main.c
+		-o $(TARGET)
 
 clean:
 	rm -f $(TARGET)

--- a/vulkan-minimal/Makefile
+++ b/vulkan-minimal/Makefile
@@ -13,10 +13,10 @@ frag.spv: shader.frag
 $(TARGET): Makefile main.c vert.spv frag.spv
 	gcc -ggdb -O0 -Wall -std=c99 \
 		-DCURRENT_DIR=\"`pwd`\" \
+		main.c \
 		`pkg-config --libs --cflags xcb` \
 		-lvulkan \
-		-o $(TARGET) \
-		main.c
+		-o $(TARGET)
 
 clean:
 	rm -f $(TARGET) vert.spv frag.spv

--- a/vulkan-triangle/Makefile
+++ b/vulkan-triangle/Makefile
@@ -15,13 +15,13 @@ $(TARGET): Makefile main.c vert.spv frag.spv \
 	common/vk-api.h common/vk-api.c
 	gcc -ggdb -O0 -Wall -std=c99 \
 		-DCURRENT_DIR=\"`pwd`\" \
+		main.c \
+		common/wsi-xcb.c \
+		common/vk-api.c \
 		`pkg-config --libs --cflags xcb` \
 		-lvulkan \
 		-DVK_USE_PLATFORM_XCB_KHR \
-		-o $(TARGET) \
-		common/wsi-xcb.c \
-		common/vk-api.c \
-		main.c
+		-o $(TARGET)
 
 clean:
 	rm -f $(TARGET) vert.spv frag.spv


### PR DESCRIPTION
If the link flags do not go at the end of the argument list, there will be unresolved symbols while linking.
